### PR TITLE
Upgrade Bootstrap and jQuery

### DIFF
--- a/app/assets/stylesheets/core_style.scss
+++ b/app/assets/stylesheets/core_style.scss
@@ -1,6 +1,5 @@
 // CSS framework
-@import "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css";
-@import "//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css";
+@import "//stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css";
 
 // Variables
 @import "variables/**/*";

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -9,7 +9,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="名古屋勉強会,らむだ,λ,ラムダ,勉強会,IT勉強会,名古屋,愛知" />
 <meta name="description" content="名古屋のIT勉強会を探すなら 『名古屋勉強会らむだ』" />
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 <script>
   $(function () {
     $('[datatoggle="tooltip"]').tooltip()

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -16,7 +16,7 @@
       <% if is_new_day %>
         <h2 class="day">
           <%= day %>
-          <small><%= "(#{event.wday})" %></small>
+          <small class="text-seconary"><%= "(#{event.wday})" %></small>
         </h2>
       <% end %>
     </div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -26,25 +26,25 @@
       <% unless is_new_day %>
         <hr class="style-two">
       <% end %>
-
-      <div class="event-left col-md-3 col-xs-3" itemprop="startDate" content="<%= "#{event.year}-#{event.month}-#{event.day}" %>">
-        <%= render partial: 'events/logo', locals: { event: event } %>
-        <%= render partial: 'events/place', locals: { event: event } %>
-      </div>
-
-      <div class="event-right col-md-9 col-xs-9">
-        <%= render partial: 'events/title', locals: { event: event } %>
-        <%= render partial: 'events/group', locals: { event: event } %>
-        <%= render partial: 'events/detail', locals: { event: event } %>
-
-        <div class="event-user">
-          <a href="<%= "#{event.twitter_list_url}" %>">
-            <%= image_tag("twitter.png", class: "twitter-icon", datatoggle: "tooltip", title: "ツイッターリスト") %>
-          </a>
-          <%= render partial: 'events/owner', collection: event.owners %>
-          <%= render partial: 'events/user', collection: event.pure_users %>
+      <div class="row">
+        <div class="event-left col-md-3 col-xs-3" itemprop="startDate" content="<%= "#{event.year}-#{event.month}-#{event.day}" %>">
+          <%= render partial: 'events/logo', locals: { event: event } %>
+          <%= render partial: 'events/place', locals: { event: event } %>
         </div>
 
+        <div class="event-right col-md-9 col-xs-9">
+          <%= render partial: 'events/title', locals: { event: event } %>
+          <%= render partial: 'events/group', locals: { event: event } %>
+          <%= render partial: 'events/detail', locals: { event: event } %>
+
+          <div class="event-user">
+            <a href="<%= "#{event.twitter_list_url}" %>">
+              <%= image_tag("twitter.png", class: "twitter-icon", datatoggle: "tooltip", title: "ツイッターリスト") %>
+            </a>
+            <%= render partial: 'events/owner', collection: event.owners %>
+            <%= render partial: 'events/user', collection: event.pure_users %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/events/_title.html.erb
+++ b/app/views/events/_title.html.erb
@@ -1,6 +1,6 @@
 <a itemprop="url" href="<%= event.event_url %>">
   <h3 class="event-title">
     <span itemprop="name"><%= event.title %></span>
-    <small> by <%= event.source %></small>
+    <small class="text-secondary"> by <%= event.source %></small>
   </h3>
 </a>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,14 +1,16 @@
-<div class="col-md-8 col-xs-12">
-  <%= render partial: 'events/event', locals: { events: @events } %>
-</div>
+<div class="row">
+  <div class="col-md-8 col-xs-12">
+    <%= render partial: 'events/event', locals: { events: @events } %>
+  </div>
 
-<div class="col-md-0 col-xs-1">
-</div>
+  <div class="col-md-0 col-xs-1">
+  </div>
 
-<div class="col-md-3 col-xs-10">
-  <% if @event.present? %>
-    <% twitter_list_url = @event.twitter_list_url %>
-    <a class="twitter-timeline" href="<%= "#{twitter_list_url}/members" %>">Tweets by TwitterDev</a>
-    <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <% end %>
+  <div class="col-md-3 col-xs-10">
+    <% if @event.present? %>
+      <% twitter_list_url = @event.twitter_list_url %>
+      <a class="twitter-timeline" href="<%= "#{twitter_list_url}/members" %>">Tweets by TwitterDev</a>
+      <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+    <% end %>
+  </div>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row mx-0">
   <div class="col-md-8 col-xs-12">
     <%= render partial: 'events/event', locals: { events: @events } %>
   </div>

--- a/app/views/events/tag.html.erb
+++ b/app/views/events/tag.html.erb
@@ -11,7 +11,7 @@
         <% if bday != day %>
         <h2 class="day">
           <%= day %>
-          <small><%= "(#{event.wday})" %></small>
+          <small class="text-secondary"><%= "(#{event.wday})" %></small>
         </h2>
         <% end %>
       </div>
@@ -54,7 +54,8 @@
           <div style="margin-bottom: 20px">
             <a itemprop="url" href="<%= event.event_url %>">
               <h3 class="event-title">
-                <span itemprop="name"><%= event.title %></span> <small>by <%= event.source %></small>
+                <span itemprop="name"><%= event.title %></span>
+                <small class="text-secondary">by <%= event.source %></small>
               </h3>
             </a>
             <% if event.group_url %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,35 +1,37 @@
 <% content_for(:html_title) { @event.group_title + ' の勉強会一覧 - 名古屋勉強会らむだ'} %>
-<div class="col-md-8 col-xs-12" style="margin-left: 20px">
-  <h2>
-    <a href="<%= "#{@event.group_url}" %>">
-      <img class="group-logo" src="<%= @event.group_logo_url %>" datatoggle="tooltip">
-      <%= "#{@event.group_title}" %>
-      <small>
-        by <%= "#{@event.source}" %>
-      </small>
-    </a>
-  </h2>
+<div class="row">
+  <div class="col-md-8 col-xs-12" style="margin-left: 20px">
+    <h2>
+      <a href="<%= "#{@event.group_url}" %>">
+        <img class="group-logo" src="<%= @event.group_logo_url %>" datatoggle="tooltip">
+        <%= "#{@event.group_title}" %>
+        <small>
+          by <%= "#{@event.source}" %>
+        </small>
+      </a>
+    </h2>
 
-  <br>
+    <br>
 
-  <h3 class="user-title">
-    <b>開催する勉強会</b>
-  </h3>
-  <%= render partial: 'events/event', locals: { events: @events } %>
+    <h3 class="user-title">
+      <b>開催する勉強会</b>
+    </h3>
+    <%= render partial: 'events/event', locals: { events: @events } %>
 
-  <br>
-  <br>
+    <br>
+    <br>
 
-  <h3 class="user-title">
-    <b>過去の勉強会</b>
-  </h3>
-  <%= render partial: 'events/event', locals: { events: @events_histories } %>
-</div>
+    <h3 class="user-title">
+      <b>過去の勉強会</b>
+    </h3>
+    <%= render partial: 'events/event', locals: { events: @events_histories } %>
+  </div>
 
-<div class="col-md-0 col-xs-1">
-</div>
+  <div class="col-md-0 col-xs-1">
+  </div>
 
-<div class="col-md-3 col-xs-10">
-  <a class="twitter-timeline" href="<%= "#{@event.twitter_list_url}/members" %>">Tweets by TwitterDev</a>
-  <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <div class="col-md-3 col-xs-10">
+    <a class="twitter-timeline" href="<%= "#{@event.twitter_list_url}/members" %>">Tweets by TwitterDev</a>
+    <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+  </div>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -5,7 +5,7 @@
       <a href="<%= "#{@event.group_url}" %>">
         <img class="group-logo" src="<%= @event.group_logo_url %>" datatoggle="tooltip">
         <%= "#{@event.group_title}" %>
-        <small>
+        <small class="text-secondary">
           by <%= "#{@event.source}" %>
         </small>
       </a>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:html_title) { @event.group_title + ' の勉強会一覧 - 名古屋勉強会らむだ'} %>
-<div class="row">
-  <div class="col-md-8 col-xs-12" style="margin-left: 20px">
+<div class="row mx-0">
+  <div class="col-md-8 col-xs-12">
     <h2>
       <a href="<%= "#{@event.group_url}" %>">
         <img class="group-logo" src="<%= @event.group_logo_url %>" datatoggle="tooltip">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
     <h2>
       <img class="user-icon" src="<%= @user.image_url %>" datatoggle="tooltip">
       <%= "#{@user.name}" %>
-      <small>
+      <small class="text-secondary">
         <%= "(@#{@user.twitter_id})" %>
       </small>
     </h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:html_title) { @user.name + ' さんの勉強会一覧 - 名古屋勉強会らむだ' } %>
-<div class="row">
-  <div class="col-md-8 col-xs-12" style="margin-left: 20px">
+<div class="row mx-0">
+  <div class="col-md-8 col-xs-12">
     <h2>
       <img class="user-icon" src="<%= @user.image_url %>" datatoggle="tooltip">
       <%= "#{@user.name}" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,33 +1,35 @@
 <% content_for(:html_title) { @user.name + ' さんの勉強会一覧 - 名古屋勉強会らむだ' } %>
-<div class="col-md-8 col-xs-12" style="margin-left: 20px">
-  <h2>
-    <img class="user-icon" src="<%= @user.image_url %>" datatoggle="tooltip">
-    <%= "#{@user.name}" %>
-    <small>
-      <%= "(@#{@user.twitter_id})" %>
-    </small>
-  </h2>
+<div class="row">
+  <div class="col-md-8 col-xs-12" style="margin-left: 20px">
+    <h2>
+      <img class="user-icon" src="<%= @user.image_url %>" datatoggle="tooltip">
+      <%= "#{@user.name}" %>
+      <small>
+        <%= "(@#{@user.twitter_id})" %>
+      </small>
+    </h2>
 
-  <br>
+    <br>
 
-  <h3 class="user-title">
-    <b>参加する勉強会</b>
-  </h3>
-  <%= render partial: 'events/event', locals: { events: @events } %>
+    <h3 class="user-title">
+      <b>参加する勉強会</b>
+    </h3>
+    <%= render partial: 'events/event', locals: { events: @events } %>
 
-  <br>
-  <br>
+    <br>
+    <br>
 
-  <h3 class="user-title">
-    <b>過去の勉強会</b>
-  </h3>
-  <%= render partial: 'events/event', locals: { events: @events_histories } %>
-</div>
+    <h3 class="user-title">
+      <b>過去の勉強会</b>
+    </h3>
+    <%= render partial: 'events/event', locals: { events: @events_histories } %>
+  </div>
 
-<div class="col-md-0 col-xs-1">
-</div>
+  <div class="col-md-0 col-xs-1">
+  </div>
 
-<div class="col-md-3 col-xs-10">
-  <a class="twitter-timeline" href="<%= "https://twitter.com/#{@user.twitter_id}" %>">Tweets by TwitterDev</a>
-  <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <div class="col-md-3 col-xs-10">
+    <a class="twitter-timeline" href="<%= "https://twitter.com/#{@user.twitter_id}" %>">Tweets by TwitterDev</a>
+    <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+  </div>
 </div>


### PR DESCRIPTION
フロントエンドの技術スタックが古くなっており、UI改善などでドキュメントを調べるにあたって支障があるように思います。このPRでは以下を更新します。

* Bootstrap 3 → 4
* jQuery 1 → 3

新しいバージョンでは

* 不具合修正
* 脆弱性対処（特にjQuery）
* ブラウザの新技術を使ったパフォーマンス最適化

などが期待できます。

今回の変更で、IE10以下はサポートされなくなりますが、IE11以上で十分でしょう。
IEを必要とする企業のレガシー環境ではIE11が主流で、一般ユーザーはEdgeかChromeなどのブラウザを使っているはずなので。


見た目の変更

* Bootstrap 4ではデフォルトのフォントサイズが `14px` から `16px` に変わったため、全体的に少し文字が大きくなりました。 個人的には見やすくなったと思いますが、小さいほうが良ければ文字サイズを変更します。
* Bootstrap4ではアイコンモジュールは廃止されました。代わりに、[Boostrap4で推奨されているアイコンモジュール](https://getbootstrap.com/docs/4.3/extend/icons/)のうち、もっともアイコン種類の豊富な Font Awesome Free に切り替えました（ほかがよければ言ってください）

