### PR TITLE
HTMLタイトルを内容に応じて区別できるようにする

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -1,4 +1,4 @@
-<title>名古屋勉強会らむだ</title>
+<title><%= content_for?(:html_title) ? yield(:html_title) : '名古屋勉強会らむだ' %></title>
 <%= csrf_meta_tags %>
 <%= stylesheet_link_tag 'application', media: 'all' %>
 <%= javascript_include_tag 'application' %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:html_title) { @event.group_title + ' の勉強会一覧 - 名古屋勉強会らむだ'} %>
 <div class="col-md-8 col-xs-12" style="margin-left: 20px">
   <h2>
     <a href="<%= "#{@event.group_url}" %>">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:html_title) { @user.name + ' さんの勉強会一覧 - 名古屋勉強会らむだ' } %>
 <div class="col-md-8 col-xs-12" style="margin-left: 20px">
   <h2>
     <img class="user-icon" src="<%= @user.image_url %>" datatoggle="tooltip">


### PR DESCRIPTION
Closes #38 

[こちらの記事で推奨されている方法](https://techracho.bpsinc.jp/hachi8833/2018_05_15/55812)を用いました。


# ユーザー別
![image](https://user-images.githubusercontent.com/127635/61179133-56bab700-a637-11e9-82b5-bb981c094d88.png)


# グループ別
![image](https://user-images.githubusercontent.com/127635/61179131-54f0f380-a637-11e9-893c-80e71697b167.png)
