### PR TITLE
遅延読込の最適化

### DIFF
--- a/app/assets/javascripts/lazyload_image.js.erb
+++ b/app/assets/javascripts/lazyload_image.js.erb
@@ -4,7 +4,7 @@ if (typeof IntersectionObserver === 'function') {
     var io = new IntersectionObserver(function (entries) {
         var that = this;
         entries.forEach(function (entry) {
-          if (entry.intersectionRatio === 0) return;
+          if (!entry.isIntersecting) return;
           entry.target.src = entry.target.dataset.origsrc;
           that.unobserve(entry.target);
         });

--- a/app/assets/javascripts/lazyload_image.js.erb
+++ b/app/assets/javascripts/lazyload_image.js.erb
@@ -23,6 +23,7 @@ if (typeof IntersectionObserver === 'function') {
     ].join(','));
 
     imgs.forEach(function (img) {
+      if (img.naturalWidth > 0) return;
       img.dataset.origsrc = img.src;
       img.src = "<%= image_path('loader-rolling.gif') %>";
       io.observe(img);


### PR DESCRIPTION
* 取得済み画像であれば遅延読込しないようにします
* 画像が見えているかどうか `intersectionRatio === 0` で数値計算せず、`isIntersecting` で判断します

<del>ぼくにはモバイル Safari にリモートデバッグする手段がないため #46 の解決になるかはわかりませんが、負荷は減ると思います。</del>たぶん関係ないと思います。