### PR TITLE
脆弱性のあるjQuery 1.12.4 から 3系へ更新

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery3
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .


### PR DESCRIPTION
https://github.com/shule517/nagoya-benkyokai/pull/36 の jQueryのバージョンアップのコミットだけを引っ越してきた。

### 変更前
jQuery ver 1.12.4
![スクリーンショット 0031-07-15 23 03 54](https://user-images.githubusercontent.com/2564871/61222100-fe79d700-a754-11e9-8a91-6540beaf931f.png)

### 変更後
jQuery ver 3.4.1(2019/07/05時点で最新)
![スクリーンショット 0031-07-15 23 06 42](https://user-images.githubusercontent.com/2564871/61222234-3e40be80-a755-11e9-854c-0d7f86f83734.png)