### PR TITLE
NGワードを追加(日本手術看護学会)

### DIFF
--- a/app/services/search_event_service.rb
+++ b/app/services/search_event_service.rb
@@ -42,7 +42,7 @@ class SearchEventService
   end
 
   def not_benkyokai_words
-    %w(終活 日本手術看護学会 終活 仏教 クリスマスパーティ テロリスト 国際交流パーティ 社会人基礎力 カウントダウンパーティー ARMENIAN SONGS ブッダ BrightWoman 幸せの種まき 幸せの花 オシャレな古城 受講料 mana×comu 投資 心理学 ヨガ 病 ベジタリアン ピアノ 幸せ Hearthstone ゆかりオフ オシャレカフェ eco検定 アニマルセラピー 介護 岩倉歌謡大道芸祭り 『なぜ生きる』 名古屋手帳オフ会)
+    %w(手術看護学会 終活 日本手術看護学会 終活 仏教 クリスマスパーティ テロリスト 国際交流パーティ 社会人基礎力 カウントダウンパーティー ARMENIAN SONGS ブッダ BrightWoman 幸せの種まき 幸せの花 オシャレな古城 受講料 mana×comu 投資 心理学 ヨガ 病 ベジタリアン ピアノ 幸せ Hearthstone ゆかりオフ オシャレカフェ eco検定 アニマルセラピー 介護 岩倉歌謡大道芸祭り 『なぜ生きる』 名古屋手帳オフ会)
   end
 
   def keywords


### PR DESCRIPTION
名古屋勉強会とは関係ないイベントが載ってしまうため、NGワードを追加
```【参加人数上限に達し募集を終了しました】日本手術看護学会東海地区　周術期看護セミナー ```